### PR TITLE
Update RFID Reader Management.postman_collection.json

### DIFF
--- a/RFID Reader Management.postman_collection.json
+++ b/RFID Reader Management.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "52bf35bb-be68-4ce6-84a8-baff44c9ecd3",
-		"name": "RFID Reader Management",
+		"name": " Zebra RFID Reader Management",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [


### PR DESCRIPTION
Ben had the idea to name Postman Collections to start with Zebra so they appear at the bottom of the postman. This is to make them easier to find, just scroll to the bottom.